### PR TITLE
create equivalent of `build.bat` for GNU

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+$python=python3
+$pip=pip3
+$pyinstaller=pyinstaller
+
+cd src
+clear
+$python --version
+echo "====================="
+$pip --version
+echo "====================="
+echo "Installing Packages..."
+$pip install -r requirements.txt
+echo "====================="
+echo "Building..."
+$pyinstaller --noconfirm --onefile --console --name "hascal"  "hascal.py"


### PR DESCRIPTION
Linux-based operating systems don't support `bat` or `cmd` commands. they have `zsh`,`bash`,`dash` instead.