### PR TITLE
Makefile: correct indentation using tab. Fix #13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build :
 	cp -r src/hlib dist/	
 	cp -r examples/ dist/	
 windows :
-    pyinstaller --noconfirm --onefile --console --name "hascal"  "src/hascal.py"
+	pyinstaller --noconfirm --onefile --console --name "hascal"  "src/hascal.py"
 	xcopy src\hlib dist\hlib /E /H /C /I
 	xcopy examples dist\examples /E /H /C /I
 deps :


### PR DESCRIPTION
Fix for error: `Makefile:8: *** missing separator.  Stop.`