### PR TITLE
No errors when main doesn't return anything

### DIFF
--- a/src/core/h_compiler.py
+++ b/src/core/h_compiler.py
@@ -1007,6 +1007,7 @@ class Generator(object):
                 _return_type != "__hascal__void"
                 and len(_expr) != 0
                 and _expr[-1].get("return") != True
+                and _name != 'main'
             ):
                 HascalError(
                     f"Function '{_name}' should return a value at end of function block:{_line}",filename=self.filename


### PR DESCRIPTION
This will add the feature of #66.
Just checking if name is not main, Then running the function.